### PR TITLE
Cleanup and Fix Analyzer crashes in analysis phase

### DIFF
--- a/classes/analyze.py
+++ b/classes/analyze.py
@@ -7,26 +7,26 @@ from settings import SimulationSettings, GameSettings, LogSettings
 
 
 class Analyzer:
-    """ Functions to analyzed games after the simulation
+    """ Functions to analyze games after the simulation
     """
 
     def __init__(self):
         self.df = pd.read_csv(LogSettings.data_log_file, sep='\t')
 
     def remaining_players(self):
-        """ How many games had clear winner, how many players remain in tha end
+        """ number of games that had a clear winner, how many players remain at the end
         """
         grouped = self.df.groupby('game_number').size().reset_index(name='Losers')
         result = grouped['Losers'].value_counts().reset_index()
+        result.columns = ['Losers', 'count']
 
         # {remaining players: games}
-        remaining_players = {len(GameSettings.players_list) - row['Losers']: row['count']
-                             for index, row in result.iterrows()}
+        remaining_players = {len(GameSettings.players_list) - row['Losers']: row['count'] for index, row in result.iterrows()}
         # Add games with no losers (all players remained)
         remaining_players[len(GameSettings.players_list)] = \
             SimulationSettings.n_games - sum(remaining_players.values())
 
-        # Games with clear winner (1 player remains)
+        # Games with clear winner (just a single player remains)
         clear_winner = 0
         if 1 in remaining_players:
             clear_winner = remaining_players[1]
@@ -62,14 +62,14 @@ class Analyzer:
         loses_counts = self.df.groupby('player').size().reset_index(name='count')
 
         # {player: games_survived}
-        survival_rate = {row['player']: row['count']
-                             for index, row in loses_counts.iterrows()}
+        loses_dict = {row['player']: row['count'] for index, row in loses_counts.iterrows()}
         print("Players' survival rate:")
+
         for player in GameSettings.players_list:
             player_name = player[0]
-            loses = survival_rate.get(player_name, 0)
-        #for player_name, loses in sorted(survival_rate.items()):
+            loses = loses_dict.get(player_name, 0)
             survivals = SimulationSettings.n_games - loses
+            
             survival_rate = survivals / SimulationSettings.n_games
             margin = 1.96 * (survival_rate * (1 - survival_rate) / SimulationSettings.n_games) ** 0.5
             print(f"  - {player_name}: {survivals} " +

--- a/classes/analyze.py
+++ b/classes/analyze.py
@@ -1,5 +1,5 @@
-''' Functions to analyze the results of the simulation
-'''
+""" Functions to analyze the results of the simulation
+"""
 
 import pandas as pd
 
@@ -7,15 +7,15 @@ from settings import SimulationSettings, GameSettings, LogSettings
 
 
 class Analyzer:
-    ''' Functions to analyzed games after the simulation
-    '''
+    """ Functions to analyzed games after the simulation
+    """
 
     def __init__(self):
         self.df = pd.read_csv(LogSettings.data_log_file, sep='\t')
 
     def remaining_players(self):
-        ''' How many games had clear winner, how many players remain in tha end
-        '''
+        """ How many games had clear winner, how many players remain in tha end
+        """
         grouped = self.df.groupby('game_number').size().reset_index(name='Losers')
         result = grouped['Losers'].value_counts().reset_index()
 
@@ -39,9 +39,9 @@ class Analyzer:
             print(f"  - {remaining}: {count} ({count * 100 / SimulationSettings.n_games:.1f}%)")
 
     def game_length(self):
-        ''' Median game length (for all finite games)
-        '''
-        # Calculate median game length, which is highest bankruptcy turn within a game
+        """ Median game length (for all finite games)
+        """
+        # Calculate median game length, which is the highest bankruptcy turn within a game
         grouped = self.df.groupby('game_number')
         filtered_groups = grouped.filter(lambda x: len(x) == len(GameSettings.players_list) - 1)
         lengths_df = filtered_groups.groupby('game_number')['turn'].max().reset_index()
@@ -54,11 +54,11 @@ class Analyzer:
 
         # Calculate average survival time (for those who goes bankrupt)
         survival_average = lengths_df["turn"].mean()
-        print(f"Average survival time (for bunkrupt players): {survival_average:.1f} turns")
+        print(f"Average survival time (for bankrupt players): {survival_average:.1f} turns")
 
     def winning_rate(self):
-        ''' Display winning (survival) rate of players
-        '''
+        """ Display winning (survival) rate of players
+        """
         loses_counts = self.df.groupby('player').size().reset_index(name='count')
 
         # {player: games_survived}
@@ -70,8 +70,8 @@ class Analyzer:
             loses = survival_rate.get(player_name, 0)
         #for player_name, loses in sorted(survival_rate.items()):
             survivals = SimulationSettings.n_games - loses
-            surv_rate = survivals / SimulationSettings.n_games
-            margin = 1.96 * (surv_rate * (1 - surv_rate) / SimulationSettings.n_games) ** 0.5
+            survival_rate = survivals / SimulationSettings.n_games
+            margin = 1.96 * (survival_rate * (1 - survival_rate) / SimulationSettings.n_games) ** 0.5
             print(f"  - {player_name}: {survivals} " +
-                  f"({surv_rate * 100:.1f} "
+                  f"({survival_rate * 100:.1f} "
                   f"+- {margin * 100:.1f}%)")

--- a/classes/board.py
+++ b/classes/board.py
@@ -228,7 +228,7 @@ class Board:
             "G2 North Carolina Avenue", 300, 26, 200, (130, 390, 900, 1100, 1275), "Green"))
         self.cells.append(CommunityChest("COM3 Community Chest"))
         self.cells.append(Property(
-            "G3 Pennsylvania Avenue", 320, 28, 200, (150, 450, 100, 1200, 1400), "Green"))
+            "G3 Pennsylvania Avenue", 320, 28, 200, (150, 450, 1000, 1200, 1400), "Green"))
 
         # 35-39
         self.cells.append(Property(

--- a/classes/board.py
+++ b/classes/board.py
@@ -1,11 +1,12 @@
-''' Class to hold board information.
+""" Class to hold board information.
 That includes:
     - Properties
-    - Special cells (Go, Jail, etc)
+    - Special cells (Go, Jail, etc.)
     - Decks (Chance, Community Chest)
-'''
+"""
 
 from settings import GameSettings
+
 
 class Cell:
     """ Cell Class, base for other classes
@@ -17,40 +18,46 @@ class Cell:
     def __str__(self):
         return self.name
 
+
 class GoToJail(Cell):
-    ''' Class for Go To Jail cell
+    """ Class for Go To Jail cell
     not much going on here
-    '''
+    """
+
 
 class LuxuryTax(Cell):
-    ''' Class for LuxuryTax
-    '''
+    """ Class for LuxuryTax
+    """
+
 
 class IncomeTax(Cell):
-    ''' Class for IncomeTax
-    '''
+    """ Class for IncomeTax
+    """
+
 
 class FreeParking(Cell):
-    ''' Class for IncomeTax
-    '''
+    """ Class for Free Parking """
+
 
 class Chance(Cell):
-    ''' Class for Chance
-    '''
+    """ Class for Chance
+    """
+
 
 class CommunityChest(Cell):
-    ''' Class for Community Chest
-    '''
+    """ Class for Community Chest
+    """
+
 
 class Property(Cell):
-    ''' Property Class (for Properties, Rails, Utilities)
-    '''
+    """ Property Class (for Properties, Rails, Utilities)
+    """
 
     def __init__(self, name, cost_base, rent_base, cost_house, rent_house, group):
-        '''
+        """
         Example of parameters for a property:
         "B2 Vermont Avenue", 100, 6, 50, (30, 90, 270, 400, 550), "Lightblue"
-        '''
+        """
         super().__init__(name)
 
         # Initial parameters (usually found on a property card):
@@ -79,11 +86,10 @@ class Property(Cell):
         self.has_houses = 0
         self.has_hotel = 0
 
-
     def calculate_rent(self, dice):
-        ''' Calculate the rent amount for this property, including monopoly, houses etc.
+        """ Calculate the rent amount for this property, including monopoly, houses etc.
         dice are used to calculate rent for utilities
-        '''
+        """
         # There is a hotel on this property
         if self.has_hotel == 1:
             return self.rent_house[-1]
@@ -101,9 +107,11 @@ class Property(Cell):
         _, dice_points, _ = dice.cast()
         return dice_points * self.monopoly_coef
 
+
 class Deck:
-    ''' Parent for Community Chest and Chance cards
-    '''
+    """ Parent for Community Chest and Chance cards
+    """
+
     def __init__(self, cards):
         # List of cards
         self.cards = cards
@@ -111,10 +119,10 @@ class Deck:
         self.pointer = 0
 
     def draw(self):
-        ''' Draw one card from the deck, and put it underneath.
+        """ Draw one card from the deck, and put it underneath.
         Actually, we don't manipulate cards, just shuffle them once
         and then just move the pointer through the deck.
-        '''
+        """
         drawn_card = self.cards[self.pointer]
         self.pointer += 1
         if self.pointer == len(self.cards):
@@ -122,26 +130,27 @@ class Deck:
         return drawn_card
 
     def remove(self, card_to_remove):
-        ''' Remove a card (used for GOOJF card)
-        '''
+        """ Remove a card (used for GOOJF card)
+        """
         self.cards.remove(card_to_remove)
         # Make sure the pointer is still okay
         if self.pointer == len(self.cards):
             self.pointer = 0
 
     def add(self, card_to_add):
-        ''' Add card (to put removed GOOJF card back in)
-        '''
+        """ Add card (to put removed GOOJF card back in)
+        """
         self.cards.insert(self.pointer - 1, card_to_add)
 
+
 class Board:
-    ''' Class collecting board related information:
+    """ Class collecting board related information:
     properties and their owners, build houses, etc
-    '''
+    """
 
     def __init__(self, settings):
-        ''' Initialize board configuration: properties, special cells etc
-        '''
+        """ Initialize board configuration: properties, special cells etc
+        """
         # Keep a copy of game settings (to use in in-game calculations)
         self.settings = settings
 
@@ -165,12 +174,12 @@ class Board:
         self.cells.append(Property(
             "B2 Vermont Avenue", 100, 6, 50, (30, 90, 270, 400, 550), "Lightblue"))
         self.cells.append(Property(
-            "B3 Connecticut Avenue",120,8,50,(40, 100, 300, 450, 600),"Lightblue"))
+            "B3 Connecticut Avenue", 120, 8, 50, (40, 100, 300, 450, 600), "Lightblue"))
 
         # 10-14
         self.cells.append(Cell("JL Jail"))
         self.cells.append(Property(
-            "C1 St.Charle's Place", 140, 10, 100, (50, 150, 450, 625, 750), "Pink"))
+            "C1 St. Charles Place", 140, 10, 100, (50, 150, 450, 625, 750), "Pink"))
         self.cells.append(Property(
             "U1 Electric Company", 150, 0, 0, (0, 0, 0, 0, 0), "Utilities"))
         self.cells.append(Property(
@@ -201,15 +210,15 @@ class Board:
 
         # 25-29
         self.cells.append(Property(
-            "R3 BnO Railroad", 200, 25, 0, (0, 0, 0, 0, 0), "Railroads"))
+            "R3 B&O Railroad", 200, 25, 0, (0, 0, 0, 0, 0), "Railroads"))
         self.cells.append(Property(
             "F1 Atlantic Avenue", 260, 22, 150, (110, 330, 800, 975, 1150), "Yellow"))
         self.cells.append(Property(
-            "F2 Ventinor Avenue", 260, 22, 150, (110, 330, 800, 975, 1150), "Yellow"))
+            "F2 Ventnor Avenue", 260, 22, 150, (110, 330, 800, 975, 1150), "Yellow"))
         self.cells.append(Property(
             "U2 Waterworks", 150, 0, 0, (0, 0, 0, 0, 0), "Utilities"))
         self.cells.append(Property(
-            "F3 Martin Gardens", 280, 24, 150, (120, 360, 850, 1025, 1200), "Yellow"))
+            "F3 Marvin Gardens", 280, 24, 150, (120, 360, 850, 1025, 1200), "Yellow"))
 
         # 30-34
         self.cells.append(GoToJail("GTJ Go To Jail"))
@@ -248,17 +257,17 @@ class Board:
             "Advance to Illinois Avenue. If you pass Go, collect $200",
             "Advance to St. Charles Place. If you pass Go, collect $200",
             "Advance to the nearest Railroad. If owned, pay owner twice " + \
-                "the rental to which they are otherwise entitled",
+            "the rental to which they are otherwise entitled",
             "Advance to the nearest Railroad. If owned, pay owner twice " + \
-                "the rental to which they are otherwise entitled",
+            "the rental to which they are otherwise entitled",
             "Advance token to nearest Utility. " + \
-                "If owned, throw dice and pay owner a total ten times amount thrown.",
+            "If owned, throw dice and pay owner a total ten times amount thrown.",
             "Bank pays you dividend of $50",
             "Get Out of Jail Free",
             "Go Back 3 Spaces",
             "Go to Jail. Go directly to Jail, do not pass Go, do not collect $200",
             "Make general repairs on all your property. For each house pay $25. " + \
-                "For each hotel pay $100",
+            "For each hotel pay $100",
             "Speeding fine $15",
             "Take a trip to Reading Railroad. If you pass Go, collect $200",
             "You have been elected Chairman of the Board. Pay each player $50",
@@ -286,11 +295,11 @@ class Board:
         ])
 
     def create_property_groups(self):
-        ''' self.groups is a convenient way to group cells by color/type,
+        """ self.groups is a convenient way to group cells by color/type,
         so we don't have to check all properties on the board, to, for example,
         update their monopoly status.
         This function populate self.groups with all properties
-        '''
+        """
         groups = {}
         for cell in self.cells:
             if not isinstance(cell, Property):
@@ -301,16 +310,16 @@ class Board:
         return groups
 
     def log_board_state(self, log):
-        ''' Log current state of the houses/hotels, free parking money
-        '''
+        """ Log current state of the houses/hotels, free parking money
+        """
         log.add(f"Available houses/hotels: {self.available_houses}/{self.available_hotels}")
         if GameSettings.free_parking_money:
             log.add(f"Free Parking Money: ${self.free_parking_money}")
 
     def log_current_map(self, log):
-        ''' Log current situation on the board,
+        """ Log current situation on the board,
         who owns what, monopolies, improvements, etc
-        '''
+        """
         log.add("\n== BOARD ==")
         for cell in self.cells:
             if not isinstance(cell, Property):
@@ -326,10 +335,10 @@ class Board:
                     f"Rent coef: {cell.monopoly_coef}, Improvements: {improvements}")
 
     def recalculate_monopoly_coeffs(self, changed_cell):
-        ''' Go through all properties in the property group and update flags:
+        """ Go through all properties in the property group and update flags:
         - monopoly_coeff
         Would be run every time, when property ownership.
-        '''
+        """
 
         # Create and populate list of owners for this group
         owners = []
@@ -345,11 +354,11 @@ class Board:
             # in a group owner of this cell has
             ownership_count = owners.count(cell.owner)
 
-            # For railroad it is 1/2/4/8 (or 2**(n-1))
+            # For railroad, it is 1/2/4/8 (or 2**(n-1))
             if cell.group == "Railroads":
                 cell.monopoly_coef = 2 ** (ownership_count - 1)
 
-            # For Utilities it is either 4 or 10
+            # For Utilities, it is either 4 or 10
             elif cell.group == "Utilities":
                 if ownership_count == 2:
                     cell.monopoly_coef = 10

--- a/classes/board.py
+++ b/classes/board.py
@@ -167,7 +167,7 @@ class Board:
 
         # 5-9
         self.cells.append(Property(
-            "R1 Reading railroad", 200, 25, 0, (0, 0, 0, 0, 0), "Railroads"))
+            "R1 Reading Railroad", 200, 25, 0, (0, 0, 0, 0, 0), "Railroads"))
         self.cells.append(Property(
             "B1 Oriental Avenue", 100, 6, 50, (30, 90, 270, 400, 550), "Lightblue"))
         self.cells.append(Chance("CH1 Chance"))
@@ -191,7 +191,7 @@ class Board:
         self.cells.append(Property(
             "R2 Pennsylvania Railroad", 200, 25, 0, (0, 0, 0, 0, 0), "Railroads"))
         self.cells.append(Property(
-            "D1 St.James Place", 180, 14, 100, (70, 200, 550, 700, 950), "Orange"))
+            "D1 St. James Place", 180, 14, 100, (70, 200, 550, 700, 950), "Orange"))
         self.cells.append(CommunityChest("COM2 Community Chest"))
         self.cells.append(Property(
             "D2 Tennessee Avenue", 180, 14, 100, (70, 200, 550, 700, 950), "Orange"))
@@ -337,7 +337,7 @@ class Board:
     def recalculate_monopoly_coeffs(self, changed_cell):
         """ Go through all properties in the property group and update flags:
         - monopoly_coeff
-        Would be run every time, when property ownership.
+        Would be run every time, when property ownership changes.
         """
 
         # Create and populate list of owners for this group

--- a/classes/dice.py
+++ b/classes/dice.py
@@ -1,14 +1,14 @@
-''' Class for Dice, a thread-safe seed-based random generator,
+""" Class for Dice, a thread-safe seed-based random generator,
 that can:
 - cast dice (with adjustable number of dice and sides)
 - shuffle a deck (community chest and chance)
-'''
+"""
 
 import random
 
 class Dice:
-    ''' Class to have dice settings, in case we want to play with that
-    '''
+    """ Class to have dice settings, in case we want to play with that
+    """
 
     def __init__(self, seed, dice_count, dice_sides, log):
         self.dice_count = dice_count
@@ -21,8 +21,8 @@ class Dice:
         self.log = log
 
     def cast(self):
-        ''' Cast dice and return: return raw cast, the score, is it a double
-        '''
+        """ Cast dice and return: return raw cast, the score, is it a double
+        """
 
         cast = [self.local_random.randint(1, self.dice_sides) for _ in range(self.dice_count)]
         self.log.add(f"Dice roll: {cast} " +
@@ -33,7 +33,7 @@ class Dice:
         return cast, sum(cast), len(set(cast)) == 1
 
     def shuffle(self, object_to_shuffle):
-        ''' Copy of random.shuffle, but with local
+        """ Copy of random.shuffle, but with local
         random generator (to be thread safe)
-        '''
+        """
         self.local_random.shuffle(object_to_shuffle)

--- a/classes/game.py
+++ b/classes/game.py
@@ -1,6 +1,8 @@
-''' Function, that wraps one game of monopoly:
-from setting up boards, players etc to making moves by all players
-'''
+""" Function, that wraps one game of monopoly:
+1. setting up the board,
+2. players
+3. making moves by all players
+"""
 
 from settings import SimulationSettings, GameSettings, LogSettings
 
@@ -12,12 +14,12 @@ from classes.log import Log
 
 
 def monopoly_game(data_for_simulation):
-    ''' Simulation of one game.
+    """ Simulation of one game.
     For convenience to set up a multi-thread,
     parameters are packed into a tuple: (game_number, game_seed):
     - "game number" is here to print out in the game log
     - "game_seed" to initialize random generator for the game
-    '''
+    """
     game_number, game_seed = data_for_simulation
 
     # Initialize game log
@@ -30,7 +32,7 @@ def monopoly_game(data_for_simulation):
     # Initialize data log
     datalog = Log(LogSettings.data_log_file)
 
-    # Initialize the board (plots, chance, community chest etc)
+    # Initialize the board (plots, chance, community chest etc.)
     board = Board(GameSettings)
 
     # Set up dice (it creates a separate random generator with initial "game_seed",

--- a/classes/log.py
+++ b/classes/log.py
@@ -1,14 +1,14 @@
-''' Class to keep a log of the game.
+""" Class to keep a log of the game.
 Challenge here was to make it thread-safe: simulator plays several games at a time,
 but the game log should be written by "whole game" chunks. This is the reason games
 will not be in order, as the order games start is not the same as the order they finish.
-'''
+"""
 
 import multiprocessing
 
 class Log:
-    ''' Class to handle logging of game events
-    '''
+    """ Class to handle logging of game events
+    """
 
     # Lock is declare on the class level,
     # so it would be shared among processes
@@ -20,15 +20,15 @@ class Log:
         self.disabled = disabled
 
     def add(self, data):
-        ''' Add a line to a Log
-        '''
+        """ Add a line to a Log
+        """
         if self.disabled:
             return
         self.content.append(data)
 
     def save(self):
-        ''' Write out the log
-        '''
+        """ Write out the log
+        """
         if self.disabled:
             return
         with self.lock:
@@ -38,8 +38,8 @@ class Log:
                     logfile.write("\n")
 
     def reset(self, first_line=""):
-        ''' Empty the log file, write first_line if provided
-        '''
+        """ Empty the log file, write first_line if provided
+        """
         with self.lock:
             with open(self.log_file_name, "w", encoding="utf-8") as logfile:
                 logfile.write(f"{first_line}\n")

--- a/classes/player.py
+++ b/classes/player.py
@@ -1,15 +1,15 @@
-''' Player Class
-'''
+""" Player Class
+"""
 
 from classes.board import Property, GoToJail, LuxuryTax, IncomeTax
 from classes.board import FreeParking, Chance, CommunityChest
 from settings import GameSettings
 
 class Player:
-    ''' Class to contain player-replated into and actions:
+    """ Class to contain player-related into and actions:
     - money, position, owned property
     - actions to buy property of handle Chance cards etc
-    '''
+    """
 
     def __init__(self, name, settings):
 
@@ -52,11 +52,11 @@ class Player:
         return self.name
 
     def net_worth(self, count_mortgaged_as_full_value=False):
-        ''' Calculate player's net worth (cache + property + houses)
+        """ Calculate player's net worth (cache + property + houses)
         count_mortgaged_as_full_value determines if we consider property mortgaged status:
         - True: count as full, for Income Tax calculation
         - False: count partially, for net worth statistics
-        '''
+        """
         net_worth = int(self.money)
 
         for cell in self.owned:
@@ -71,13 +71,13 @@ class Player:
         return net_worth
 
     def make_a_move(self, board, players, dice, log):
-        ''' Main function for a player to make a move
+        """ Main function for a player to make a move
         Receives:
         - a board, with all cells and other things
         - other players (in case we need to make transactions with them)
         - dice (to roll)
         - log handle
-        '''
+        """
 
         # Is player is bankrupt - do nothing
         if self.is_bankrupt:
@@ -189,14 +189,14 @@ class Player:
 
 
     def handle_salary(self, board, log):
-        ''' Adding Salary to the player's money, according to the game's settings
-        '''
+        """ Adding Salary to the player's money, according to the game's settings
+        """
         self.money += board.settings.salary
         log.add(f"Player {self.name} receives salary ${board.settings.salary}")
 
     def handle_going_to_jail(self, message, log):
-        ''' Start the jail time
-        '''
+        """ Start the jail time
+        """
         log.add(f"{self} {message}, and goes to Jail.")
         self.position = 10
         self.in_jail = True
@@ -205,9 +205,9 @@ class Player:
 
 
     def handle_being_in_jail(self, dice_roll_is_double, board, log):
-        ''' Handle player being in Jail
+        """ Handle player being in Jail
         Return True if the player stays in jail (to end his turn)
-        '''
+        """
         # Get out of jail on rolling double
         if self.get_out_of_jail_chance or self.get_out_of_jail_comm_chest:
             log.add(f"{self} uses a GOOJF card")
@@ -242,9 +242,9 @@ class Player:
 
 
     def handle_chance(self, board, players, log):
-        ''' Draw and act on a Chance card
+        """ Draw and act on a Chance card
         Return True if the move should be over (go to jail)
-        '''
+        """
         card = board.chance.draw()
         log.add(f"{self} drew Chance card: '{card}'")
 
@@ -353,9 +353,9 @@ class Player:
 
 
     def handle_community_chest(self, board, players, log):
-        ''' Draw and act on a Community Chest card
+        """ Draw and act on a Community Chest card
         Return True if the move should be over (go to jail)
-        '''
+        """
 
         card = board.chest.draw()
         log.add(f"{self} drew Community Chest card: '{card}'")
@@ -442,9 +442,9 @@ class Player:
 
 
     def handle_income_tax(self, board, log):
-        ''' Handle Income tax: choose which option
+        """ Handle Income tax: choose which option
         (fix or %) is less money and go with it
-        '''
+        """
         # Choose smaller between fixed rate and percentage
         tax_to_pay = min(
             GameSettings.income_tax,
@@ -460,12 +460,12 @@ class Player:
 
 
     def handle_landing_on_property(self, board, players, dice, log):
-        ''' Landing on property: either buy it or pay rent
-        '''
+        """ Landing on property: either buy it or pay rent
+        """
 
         def is_willing_to_buy_property(property_to_buy):
-            ''' Check if the player is willing to buy an unowned property
-            '''
+            """ Check if the player is willing to buy an unowned property
+            """
             # Player has money lower than unspendable minimum
             if self.money - property_to_buy.cost_base < self.settings.unspendable_cash:
                 return False
@@ -484,8 +484,8 @@ class Player:
             return True
 
         def buy_property(property_to_buy):
-            ''' Player buys the property
-            '''
+            """ Player buys the property
+            """
             property_to_buy.owner = self
             self.owned.append(property_to_buy)
             self.money -= property_to_buy.cost_base
@@ -542,16 +542,16 @@ class Player:
 
 
     def improve_properties(self, board, log):
-        ''' While there is money to spend and properties to improve,
+        """ While there is money to spend and properties to improve,
         keep building houses/hotels
-        '''
+        """
 
         def get_next_property_to_improve():
-            ''' Decide what is the next property to improve:
+            """ Decide what is the next property to improve:
             - it should be eligible for improvement (is monopoly, not mortgaged,
             has not more houses than other cells in the group)
             - start with cheapest
-            '''
+            """
             can_be_improved = []
             for cell in self.owned:
                 # Property has to be:
@@ -613,10 +613,10 @@ class Player:
                 log.add(f"{self} built a hotel on {cell_to_improve}")
 
     def unmortgage_a_property(self, board, log):
-        ''' Go through the list of properties and unmortgage one,
+        """ Go through the list of properties and unmortgage one,
         if there is enough money to do so. Return True, if any unmortgaging
         took place (to call it again)
-        '''
+        """
 
         for cell in self.owned:
             if cell.is_mortgaged:
@@ -633,60 +633,59 @@ class Player:
         return False
 
     def raise_money(self, required_amount, board, log):
-        ''' Part of "Pay money" method. If there is not enough cash, player has to 
+        """ Part of "Pay money" method. If there is not enough cash, player has to
         sell houses, hotels, mortgage property until you get required_amount of money
-        '''
+        """
 
-        def get_next_property_to_deimprove(required_amount):
-            ''' Get the next property to sell houses/hotel from.
+        def get_next_property_to_downgrade(required_amount):
+            """ Get the next property to sell houses/hotel from.
             Logic goes as follows:
             - if you can sell a house, sell a house (otherwise seel a hotel, if you have no choice)
             - sell one that would bring you just above the required amount (or the most expensive)
-            '''
+            """
 
             # 1. let's see which properties CAN be de-improved
             # The house/hotel count is the highest in the group
-            can_be_deimproved = []
-            can_be_deimproved_has_houses = False
+            can_be_downgrade = []
+            can_be_downgrade_has_houses = False
             for cell in self.owned:
                 if cell.has_houses > 0 or cell.has_hotel > 0:
                     # Look at other cells in this group
                     # Do they have more houses or hotels?
                     # If so this property cannot be de-improved
                     for other_cell in board.groups[cell.group]:
-                        if cell.has_hotel == 0 and (other_cell.has_houses > cell.has_houses or \
-                           other_cell.has_hotel > 0):
+                        if cell.has_hotel == 0 and (other_cell.has_houses > cell.has_houses or other_cell.has_hotel > 0):
                             break
                     else:
-                        can_be_deimproved.append(cell)
+                        can_be_downgrade.append(cell)
                         if cell.has_houses > 0:
-                            can_be_deimproved_has_houses = True
+                            can_be_downgrade_has_houses = True
 
             # No further de-improvements possible
-            if len(can_be_deimproved) == 0:
+            if len(can_be_downgrade) == 0:
                 return None
 
             # 2. If there are houses and hotels, remove hotels from the list
             # Selling a hotel is a last resort
-            if can_be_deimproved_has_houses:
-                can_be_deimproved = [x for x in can_be_deimproved if x.has_hotel == 0]
+            if can_be_downgrade_has_houses:
+                can_be_downgrade = [x for x in can_be_downgrade if x.has_hotel == 0]
 
             # 3. Find one that's just above the required amount (or the most expensive one)
             # Sort potential de-improvements from cheap to expensive
-            can_be_deimproved.sort(key = lambda x: x.cost_house // 2)
+            can_be_downgrade.sort(key = lambda x: x.cost_house // 2)
             while True:
                 # Only one possible option left
-                if len(can_be_deimproved) == 1:
-                    return can_be_deimproved[0]
+                if len(can_be_downgrade) == 1:
+                    return can_be_downgrade[0]
                 # Second expensive option is not enough, sell most expensive
-                if can_be_deimproved[-2].cost_house // 2 < required_amount:
-                    return can_be_deimproved[-1]
+                if can_be_downgrade[-2].cost_house // 2 < required_amount:
+                    return can_be_downgrade[-1]
                 # Remove most expensive option
-                can_be_deimproved.pop()
+                can_be_downgrade.pop()
 
         def get_list_of_properties_to_mortgage():
-            ''' Put together a list of properties a player can sell houses from.
-            '''
+            """ Put together a list of properties a player can sell houses from.
+            """
             list_to_mortgage = []
             for cell in self.owned:
                 if not cell.is_mortgaged:
@@ -701,7 +700,7 @@ class Player:
         # all houses/hotels are sold or enough money is raised
         while True:
             money_to_raise = required_amount - self.money
-            cell_to_deimprove = get_next_property_to_deimprove(money_to_raise)
+            cell_to_deimprove = get_next_property_to_downgrade(money_to_raise)
 
             if cell_to_deimprove is None or money_to_raise <= 0:
                 break
@@ -751,15 +750,15 @@ class Player:
             log.add(f"{self} mortgages {cell_to_mortgage}, raising ${mortgage_price}")
 
     def pay_money(self, amount, payee, board, log):
-        ''' Function to pay money to another player (or bank)
+        """ Function to pay money to another player (or bank)
         This is where Bankruptcy is triggered.
-        '''
+        """
 
         def count_max_raisable_money():
-            ''' How much cash a plyer can produce?
+            """ How much cash a plyer can produce?
             Used to determine if they should go bankrupt or not.
             Max raisable money are 1/2 of houses cost + 1/2 of unmortgaged properties cost
-            '''
+            """
             max_raisable = self.money
             for cell in self.owned:
                 if cell.has_houses > 0:
@@ -771,8 +770,8 @@ class Player:
             return max_raisable
 
         def transfer_all_properties(payee, board, log):
-            ''' Part of bankruptcy procedure, transfer all mortgaged property to the creditor
-            '''
+            """ Part of bankruptcy procedure, transfer all mortgaged property to the creditor
+            """
 
             while self.owned:
                 cell_to_transfer = self.owned.pop()
@@ -813,7 +812,7 @@ class Player:
                 board.free_parking_money += amount
 
 
-        # Bunkruptcy (can't pay even after selling and mortgaging all)
+        # Bankruptcy (can't pay even after selling and mortgaging all)
         else:
             log.add(f"{self} has to pay ${amount}, max they can raise is ${max_raisable_money}")
             self.is_bankrupt = True
@@ -837,11 +836,11 @@ class Player:
             self.wants_to_buy = set()
 
     def update_lists_of_properties_to_trade(self, board):
-        ''' Update list of properties player is willing to sell / buy
-        '''
+        """ Update list of properties player is willing to sell / buy
+        """
 
         # If player is not willing to trade, he would
-        # have not declare his offered and desired properties,
+        # have not declared his offered and desired properties,
         # thus stopping any trade with them
         if not self.settings.participates_in_trades:
             return
@@ -866,7 +865,7 @@ class Player:
                 else:
                     owned_by_others.append(cell)
 
-            # If there properties to buy - no trades
+            # If there are properties to buy - no trades
             if not_owned:
                 continue
             # If I own 1: I am ready to sell it
@@ -878,15 +877,15 @@ class Player:
 
 
     def do_a_two_way_trade(self, players, board, log):
-        ''' Look for and perform a two-way trade
-        '''
+        """ Look for and perform a two-way trade
+        """
 
         def get_price_difference(gives, receives):
-            ''' Calculate price difference between items player
+            """ Calculate price difference between items player
             is about to give minus what he is about to receive.
             >0 means player gives away more
             Return both absolute (in $), relative for a giver, relative for a receiver
-            '''
+            """
 
             cost_gives = sum(cell.cost_base for cell in gives)
             cost_receives = sum(cell.cost_base for cell in receives)
@@ -906,8 +905,8 @@ class Player:
             return new_cells
 
         def fair_deal(player_gives, player_receives, other_player):
-            ''' Remove properties from to_sell and to_buy to make it as fair as possible
-            '''
+            """ Remove properties from to_sell and to_buy to make it as fair as possible
+            """
 
             # First, get all colors in both sides of the deal
             color_receives = [cell.group for cell in player_receives]

--- a/classes/player.py
+++ b/classes/player.py
@@ -26,9 +26,9 @@ class Player:
         # Person's roll double and jail status
         # Is the player currently in jail
         self.in_jail = False
-        # How any doubles player thrown so far
+        # number of doubles each player thrown so far
         self.had_doubles = 0
-        # How many days in jail player spent so far
+        # number of days in jail each player spent so far
         self.days_in_jail = 0
         # Does player have a GOOJF card
         self.get_out_of_jail_chance = False
@@ -42,7 +42,7 @@ class Player:
         self.wants_to_sell = set()
         self.wants_to_buy = set()
 
-        # Bankrupt (game ended for thi player)
+        # Bankrupt (game ended for this player)
         self.is_bankrupt = False
 
         # Placeholder for various flags used throughout the game
@@ -79,7 +79,7 @@ class Player:
         - log handle
         """
 
-        # Is player is bankrupt - do nothing
+        # If the player bankrupt - do nothing
         if self.is_bankrupt:
             return None
 
@@ -120,7 +120,7 @@ class Player:
         # Get salary if we passed go on the way
         if self.position >= 40:
             self.handle_salary(board, log)
-        # Get the correct position, if we passed GO
+        # Get the correct position if we passed GO
         self.position %= 40
         log.add(f"Player {self.name} goes to: {board.cells[self.position].name}")
 
@@ -172,7 +172,7 @@ class Player:
         # Reset Other notes flag
         self.other_notes = ""
 
-        # If player went bankrupt this turn - return string "bankrupt"
+        # If player went bankrupt, this turn - return string "bankrupt"
         if self.is_bankrupt:
             return "bankrupt"
 

--- a/monopoly_simulator.py
+++ b/monopoly_simulator.py
@@ -1,6 +1,3 @@
-''' Main file to run monopoly simulation
-'''
-
 import random
 import concurrent.futures
 
@@ -14,9 +11,9 @@ from classes.game import monopoly_game
 
 
 def run_simulation(config):
-    ''' Run the simulation
-    In: Simulation parameters (number of games, seed etc)
-    '''
+    """
+    In: Simulation parameters (number of games, seed etc.)
+    """
 
     # Empty the game log file (list of all player actions)
     log = Log(LogSettings.game_log_file)
@@ -38,7 +35,7 @@ def run_simulation(config):
         (i + 1, random.random())
         for i in range(config.n_games)]
 
-    # Simulate each game with multi-processing
+    # Simulate each game with multiprocessing
     with concurrent.futures.ProcessPoolExecutor(max_workers=config.multi_process) as executor:
         list(tqdm(executor.map(monopoly_game, data_for_simulation), total=len(data_for_simulation)))
 

--- a/monopoly_simulator.py
+++ b/monopoly_simulator.py
@@ -39,7 +39,7 @@ def run_simulation(config):
     with concurrent.futures.ProcessPoolExecutor(max_workers=config.multi_process) as executor:
         list(tqdm(executor.map(monopoly_game, data_for_simulation), total=len(data_for_simulation)))
 
-    # Print analysis of the simulation (data is read from datalog file)
+    # Print analysis of the simulation (data is read from the datalog file)
     analysis = Analyzer()
     analysis.remaining_players()
     analysis.game_length()

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 """ Config file for monopoly simulation
 """
 
+
 class SimulationSettings:
     # Number of moves to simulate
     # (if there are more than one player alive after then,
@@ -16,8 +17,9 @@ class SimulationSettings:
     # Number of parallel processes to use in the simulation
     multi_process = 4
 
+
 class LogSettings:
-    # Detailed log about all that is going on in th game:
+    # Detailed log about all that is going on in the game:
     # movements, purchases, rent, cards, etc.
     # Note that it takes about 5Mb per one 1000-turn game.
     # Might want to turn it off for large simulations
@@ -28,11 +30,12 @@ class LogSettings:
     # Base info for all simulation analysis
     data_log_file = "datalog.txt"
 
+
 class StandardPlayerSetting:
     # Amount of money player wants to keep unspent (money safety pillow)
     unspendable_cash = 200
 
-    # Group of properties, player refuse to buy (set, as there may be several)
+    # Group of properties, player refuses to buy (set, as there may be several)
     ignore_property_groups = {}
 
     # Willing to participate in trades
@@ -40,15 +43,17 @@ class StandardPlayerSetting:
 
     # Only agree to trade if value difference is within these limits
     # (Absolute and relative)
-    trade_max_diff_abs = 200 # More expensive - less expensive
-    trade_max_diff_rel = 2 # More expensive / less expensive
+    trade_max_diff_abs = 200  # More expensive - less expensive
+    trade_max_diff_rel = 2  # More expensive / less expensive
+
 
 class ExperimentPlayerSetting(StandardPlayerSetting):
     """ Changed settings for the Experiment Player
     """
 
+
 class GameSettings:
-    """ Setting for the game (rules + player list)
+    """ Setting for the game (rules and player list)
     """
     # Dice settings
     dice_count = 2
@@ -65,8 +70,7 @@ class GameSettings:
     # Randomly shuffle order of players each game
     shuffle_players = True
 
-    # Initial money (a single integer if it is same
-    # for everybody or a list of values for individual values)
+    # Initial money (a single integer if it is the same for everybody or a list of values for individual values)
     starting_money = 1500
     # starting_money = [1415, 1470, 1530, 1585]
 
@@ -86,10 +90,10 @@ class GameSettings:
     income_tax = 200
     income_tax_percentage = .1
 
-    # Mortgage value: how much cash player gets for mortgaging a property
+    # Mortgage value: how much cash a player gets for mortgaging a property
     # Default is 0.5
     mortgage_value = 0.5
-    # Mortgage fee is an extra they need to pay to unmortgage
+    # The Mortgage fee is an extra they need to pay to unmortgage
     # Default is 0.1
     mortgage_fee = 0.1
 

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,7 @@
-''' Config file for monopoly simulation
-'''
+""" Config file for monopoly simulation
+"""
 
-class SimulationSettings():
-    ''' Simulation settings
-    '''
-
+class SimulationSettings:
     # Number of moves to simulate
     # (if there are more than one player alive after then,
     # the game is considered to have no winner)
@@ -20,22 +17,18 @@ class SimulationSettings():
     multi_process = 4
 
 class LogSettings:
-    ''' Settings for logging
-    '''
     # Detailed log about all that is going on in th game:
-    # movements, purchases, rent, cards, etc
+    # movements, purchases, rent, cards, etc.
     # Note that it takes about 5Mb per one 1000-turn game.
     # Might want to turn it off for large simulations
     keep_game_log = True
     game_log_file = "gamelog.txt"
 
-    # Log that keeps information about on which turn which player went bunkrupt
+    # Log that keeps information about on which turn which player went bankrupt
     # Base info for all simulation analysis
     data_log_file = "datalog.txt"
 
-class StandardPlayer:
-    ''' Settings for a Standard Player
-    '''
+class StandardPlayerSetting:
     # Amount of money player wants to keep unspent (money safety pillow)
     unspendable_cash = 200
 
@@ -50,23 +43,23 @@ class StandardPlayer:
     trade_max_diff_abs = 200 # More expensive - less expensive
     trade_max_diff_rel = 2 # More expensive / less expensive
 
-class ExperimentPlayer(StandardPlayer):
-    ''' Changed settings for the Experiment Player
-    '''
+class ExperimentPlayerSetting(StandardPlayerSetting):
+    """ Changed settings for the Experiment Player
+    """
 
-class GameSettings():
-    ''' Setting for the game (rules + player list)
-    '''
+class GameSettings:
+    """ Setting for the game (rules + player list)
+    """
     # Dice settings
     dice_count = 2
     dice_sides = 6
 
     # Players and their behavior settings
     players_list = [
-        ("Experiment", ExperimentPlayer),
-        ("Standard 1", StandardPlayer),
-        ("Standard 2", StandardPlayer),
-        ("Standard 3", StandardPlayer),
+        ("Experiment", ExperimentPlayerSetting),
+        ("Standard 1", StandardPlayerSetting),
+        ("Standard 2", StandardPlayerSetting),
+        ("Standard 3", StandardPlayerSetting),
     ]
 
     # Randomly shuffle order of players each game
@@ -93,7 +86,7 @@ class GameSettings():
     income_tax = 200
     income_tax_percentage = .1
 
-    # Mortgage value: how much cash player get's for mortgaging a property
+    # Mortgage value: how much cash player gets for mortgaging a property
     # Default is 0.5
     mortgage_value = 0.5
     # Mortgage fee is an extra they need to pay to unmortgage

--- a/settings.py
+++ b/settings.py
@@ -31,7 +31,7 @@ class LogSettings:
     data_log_file = "datalog.txt"
 
 
-class StandardPlayerSetting:
+class StandardPlayerSettings:
     # Amount of money player wants to keep unspent (money safety pillow)
     unspendable_cash = 200
 
@@ -47,8 +47,8 @@ class StandardPlayerSetting:
     trade_max_diff_rel = 2  # More expensive / less expensive
 
 
-class ExperimentPlayerSetting(StandardPlayerSetting):
-    """ Changed settings for the Experiment Player
+class HeroPlayerSettingsSettings(StandardPlayerSettings):
+    """ here you can change the settings of the hero (the Experimental Player)
     """
 
 
@@ -61,10 +61,10 @@ class GameSettings:
 
     # Players and their behavior settings
     players_list = [
-        ("Experiment", ExperimentPlayerSetting),
-        ("Standard 1", StandardPlayerSetting),
-        ("Standard 2", StandardPlayerSetting),
-        ("Standard 3", StandardPlayerSetting),
+        ("Hero", HeroPlayerSettingsSettings),
+        ("opponent 1", StandardPlayerSettings),
+        ("opponent 2", StandardPlayerSettings),
+        ("opponent 3", StandardPlayerSettings),
     ]
 
     # Randomly shuffle order of players each game

--- a/settings.py
+++ b/settings.py
@@ -12,7 +12,7 @@ class SimulationSettings:
     n_games = 1000
 
     # Random seed to start simulation with
-    seed = 0
+    seed = 42
 
     # Number of parallel processes to use in the simulation
     multi_process = 4


### PR DESCRIPTION
This PR fixes a wrong value at G3 Pennsylvania Avenue and two bugs in the Analyzer class:

1. fix value of "G3 Pennsylvania Avenue" with 3 house: it was 100 instead of 1000
2. Ensures 'count' column exists after value_counts() + reset_index() in remaining_players()
3. Avoids overwriting survival_rate dictionary with a float in winning_rate()

Without these fixes, simulations crash at analysis phase.
All simulation outputs now complete without exceptions.

